### PR TITLE
Add support for OWON P4000 series (tested on P4603 model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ with OwonPSU("/dev/ttyUSB0") as opsu:
 from owon_psu import OwonPSU
 
 opsu = OwonPSU("/dev/ttyUSB0")
+opsu.open()
 print("Identity:", opsu.read_identity())
 print("Voltage:", opsu.measure_voltage())
 print("Current:", opsu.measure_current())
@@ -53,4 +54,5 @@ opsu.set_voltage_limit(30)
 opsu.set_current_limit(3)
 print("Output enabled:", opsu.get_output())
 opsu.set_output(True)
+opsu.close()
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Owon SPEx103 PSU python control library
-This library works with the Owon SPE6103 and SPE3103 power supplies.
+# Owon SPE and P4000 series PSU python control library
+This library works with the Owon SPE6103, SPE3103, and P4000 series (P4603 and P4305) power supplies.
 Kiprim devices "DC310S" and "DC605S" are also supported.
 
 ## Installation

--- a/owon_psu/__init__.py
+++ b/owon_psu/__init__.py
@@ -90,6 +90,15 @@ class OwonPSU:
   def set_output(self, enabled):
     self._silent_cmd(f"OUTPut {'ON' if enabled else 'OFF'}")
 
+  # System Control Commands: equivalent to 'Keylock' button on P4000 series
+  def set_keylock(self, enabled):
+    if enabled:
+      # Note: SYSTem:REMote does not work on P4603
+      self._silent_cmd("SYST:REM")
+    else:
+      # Note: SYSTem:LOCal does not work on P4603
+      self._silent_cmd("SYST:LOC")
+
 if __name__ == "__main__":
   import sys
   port_name = sys.argv[1]

--- a/owon_psu/__init__.py
+++ b/owon_psu/__init__.py
@@ -7,7 +7,7 @@ import serial
 
 class OwonPSU:
 
-  SUPPORTED_DEVICES = {"OWON,SPE", "OWON,SPM", "KIPRIM,DC"}
+  SUPPORTED_DEVICES = {"OWON,SPE", "OWON,SPM", "OWON,P4","KIPRIM,DC"}
 
   def __init__(self, port, default_timeout=0.5):
     self.ser = None
@@ -80,6 +80,9 @@ class OwonPSU:
 
   def get_output(self):
     ret = self._cmd(f"OUTPut?")
+    if ret in ["0", "1"]:
+      return ret == "1"
+
     if ret not in ["ON", "OFF"]:
       raise Exception(f"Unknown return for get output command: {ret}")
     return ret == "ON"


### PR DESCRIPTION
Added support for the OWON P4000 series power suppliers, per manual:
https://files.owon.com.cn/software/Application/P4000_Series_DC_Power_Supply_Programming_Manual.pdf

Product/Series Overview:
https://www.owon.com.hk/products_owon_p4000_series_1ch_liner_dc_power_supply

Mostly compatible, except:
OUTPut? command returns {0|1} instead of {OFF|ON} (set command will accept either {0|1|OFF|ON})

Also updated README.md "without context manager" example to include missing open() and close() 

Second commit is to add set_keylock() function that will disable front panel keys (for remote use).  This command comes from the SPE series manual:
https://files.owon.com.cn/software/Application/SP_and_SPE_SPS_programming_manual.pdf
(See "System control Commands")
... but also works on the P4000 series as well (as long as command is short version: `SYST:REM` or `SYST:LOC`)

Note: based on OWON site: https://www.owon.com.hk/list_programmable_dc_series
... this library would likely work on other models beyond SPE & P4000 as well (i.e., SP, SPM, and SPS series)

However, I only have a P4000 series supply and cannot test other models myself.